### PR TITLE
use local timezone when inserting to clickhouse

### DIFF
--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -79,6 +79,6 @@ func (dt *Date) parse(value string) (int64, error) {
 		time.Time(tv).Year(),
 		time.Time(tv).Month(),
 		time.Time(tv).Day(),
-		0, 0, 0, 0, time.UTC,
+		0, 0, 0, 0, time.Local,
 	).Unix(), nil
 }


### PR DESCRIPTION
I had 2 fields, Date and DateTime, when I'm inserting data into them, using time.Now(), one of the fields gets data saved in UTC instead of Local. This pull request will "sync" so both fields will be saved in local timezone.